### PR TITLE
feat(userscript): 支持 business.gemini.google 域名注入（fix #26）

### DIFF
--- a/build.js
+++ b/build.js
@@ -40,6 +40,7 @@ const userscriptBanner = `// ==UserScript==
 // @author       journey-ad
 // @license      MIT
 // @match        https://gemini.google.com/*
+// @match        https://business.gemini.google/*
 // @connect      googleusercontent.com
 // @grant        GM_xmlhttpRequest
 // @grant        unsafeWindow

--- a/tests/userscript/userscriptMatchDomains.test.js
+++ b/tests/userscript/userscriptMatchDomains.test.js
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test('userscript metadata should match gemini.google.com and business.gemini.google', () => {
+    const buildScript = readFileSync(new URL('../../build.js', import.meta.url), 'utf8');
+
+    assert.match(buildScript, /\/\/ @match\s+https:\/\/gemini\.google\.com\/\*/);
+    assert.match(buildScript, /\/\/ @match\s+https:\/\/business\.gemini\.google\/\*/);
+});


### PR DESCRIPTION
## 背景
Issue #26 反馈 userscript 在 `business.gemini.google` 页面不生效，原因是元数据 `@match` 仅覆盖 `gemini.google.com`。

## 变更
- 在 userscript banner 中新增：
  - `// @match        https://business.gemini.google/*`
- 新增回归测试：
  - `tests/userscript/userscriptMatchDomains.test.js`
  - 断言 `build.js` 中同时存在：
    - `https://gemini.google.com/*`
    - `https://business.gemini.google/*`

## 测试
- `node --test tests/userscript/userscriptMatchDomains.test.js`
- `npm test`
- `npm run build`
- 构建产物校验：`dist/userscript/gemini-watermark-remover.user.js` 中存在两条 `@match`

## 影响范围
- 仅扩展 userscript 注入域名范围，不改动水印处理逻辑与算法。
- 对现有 `gemini.google.com` 行为无破坏性影响。

Closes #26