### PR TITLE
fix(core): prevent TypeError when hasReliableStandardWatermarkSignal receives null or undefined

### DIFF
--- a/src/core/watermarkPresence.js
+++ b/src/core/watermarkPresence.js
@@ -3,7 +3,9 @@ import {
     classifyStandardWatermarkSignal
 } from './watermarkDecisionPolicy.js';
 
-export function hasReliableStandardWatermarkSignal({ spatialScore, gradientScore }) {
+export function hasReliableStandardWatermarkSignal(scores) {
+    if (!scores) return false;
+    const { spatialScore, gradientScore } = scores;
     return classifyStandardWatermarkSignal({ spatialScore, gradientScore }).tier === 'direct-match';
 }
 

--- a/tests/core/watermarkPresence.test.js
+++ b/tests/core/watermarkPresence.test.js
@@ -46,6 +46,12 @@ test('hasReliableStandardWatermarkSignal should reject weak low-gradient false p
     );
 });
 
+test('hasReliableStandardWatermarkSignal should return false safely for null or undefined inputs', () => {
+    assert.equal(hasReliableStandardWatermarkSignal(null), false);
+    assert.equal(hasReliableStandardWatermarkSignal(undefined), false);
+    assert.equal(hasReliableStandardWatermarkSignal(), false);
+});
+
 test('hasReliableAdaptiveWatermarkSignal should accept strong adaptive Gemini match', () => {
     assert.equal(
         hasReliableAdaptiveWatermarkSignal({


### PR DESCRIPTION
Update hasReliableStandardWatermarkSignal to safely handle null, undefined, or missing input parameters rather than attempting to destructure them directly, and add corresponding unit tests to verify the safe fallback behavior.